### PR TITLE
Safely dispatch without password

### DIFF
--- a/lib/hooks/index.js
+++ b/lib/hooks/index.js
@@ -1,5 +1,7 @@
 const hashPassword = require('./hash-password');
+const protect = require('./protect');
 
 module.exports = {
-  hashPassword
+  hashPassword,
+  protect
 };

--- a/lib/hooks/protect.js
+++ b/lib/hooks/protect.js
@@ -1,0 +1,24 @@
+const omit = require('lodash.omit');
+
+module.exports = function (...fields) {
+  return function protect (hook) {
+    const result = hook.dispatch || hook.result;
+    const o = current => omit(current, fields);
+
+    if (!result) {
+      return hook;
+    }
+
+    if (Array.isArray(result)) {
+      hook.dispatch = result.map(o);
+    } else if (result.data) {
+      hook.dispatch = Object.assign({}, result, {
+        data: result.data.map(o)
+      });
+    } else {
+      hook.dispatch = o(result);
+    }
+
+    return hook;
+  };
+};

--- a/test/hooks/protect.test.js
+++ b/test/hooks/protect.test.js
@@ -1,0 +1,89 @@
+/* eslint-disable no-unused-expressions */
+const chai = require('chai');
+
+const { protect } = require('../../lib/hooks');
+const { expect } = chai;
+
+function testOmit (title, property) {
+  describe(title, () => {
+    const fn = protect('password');
+
+    it('omits from object', () => {
+      const data = {
+        email: 'test@user.com',
+        password: 'supersecret'
+      };
+      const context = {
+        [property]: data
+      };
+      const result = fn(context);
+
+      expect(result).to.deep.equal({
+        [property]: data,
+        dispatch: { email: 'test@user.com' }
+      });
+    });
+
+    it('omits from array', () => {
+      const data = [{
+        email: 'test1@user.com',
+        password: 'supersecret'
+      }, {
+        email: 'test2@user.com',
+        password: 'othersecret'
+      }];
+      const context = {
+        [property]: data
+      };
+      const result = fn(context);
+
+      expect(result).to.deep.equal({
+        [property]: data,
+        dispatch: [
+          { email: 'test1@user.com' },
+          { email: 'test2@user.com' }
+        ]
+      });
+    });
+
+    it('omits from pagination object', () => {
+      const data = {
+        total: 2,
+        data: [{
+          email: 'test1@user.com',
+          password: 'supersecret'
+        }, {
+          email: 'test2@user.com',
+          password: 'othersecret'
+        }]
+      };
+      const context = {
+        [property]: data
+      };
+      const result = fn(context);
+
+      expect(result).to.deep.equal({
+        [property]: data,
+        dispatch: {
+          total: 2,
+          data: [
+            { email: 'test1@user.com' },
+            { email: 'test2@user.com' }
+          ]
+        }
+      });
+    });
+  });
+}
+
+describe('hooks:protect', () => {
+  it('does nothing when called with no result', () => {
+    const fn = protect();
+    const original = {};
+
+    expect(fn(original)).to.deep.equal(original);
+  });
+
+  testOmit('with hook.result', 'result');
+  testOmit('with hook.dispatch already set', 'dispatch');
+});


### PR DESCRIPTION
Uses v3 `hook.dispatch` to set a "safe" version of the user object to dispatch.