### PR TITLE
Adding tests and calling to hasOwnProperty on Object.prototype instead of assuming valid prototype

### DIFF
--- a/lib/hooks/hash-password.js
+++ b/lib/hooks/hash-password.js
@@ -37,7 +37,7 @@ module.exports = function hashPassword (options = {}) {
     const data = dataIsArray ? context.data : [ context.data ];
 
     return Promise.all(data.map(item => {
-      if (item.hasOwnProperty(field)) {
+      if (Object.prototype.hasOwnProperty.call(item, field)) {
         return hashPw(item[field]).then(hashedPassword => {
           return Object.assign(item, {
             [field]: hashedPassword

--- a/test/hooks/hash-password.test.js
+++ b/test/hooks/hash-password.test.js
@@ -46,6 +46,15 @@ describe('hooks:hashPassword', () => {
     });
   });
 
+  describe('when data does not have a prototype', () => {
+    it('does not do anything', () => {
+      hook.data = Object.create(null);
+      return hashPassword()(hook).then(returnedHook => {
+        expect(returnedHook).to.deep.equal(hook);
+      });
+    });
+  });
+
   describe('when password does not exist', () => {
     it('does not do anything', () => {
       delete hook.data.password;


### PR DESCRIPTION
### Summary

- This PR is for solving an issue with the hash-password hook.
      The issue is that hash password hook assumes that the request body will come with a prototype associated which might not be the case, for example when used alongside multer, the request body gets regenerated with Object.create(null). This is not an issue with multer or any other library as is intended to avoid vulnerabilities.
      The PR solves a undefined exception triggered on: ./lib/hooks/hash-password.js:40

- There are no open issues related to this PR that I'm aware of.
- No dependency on other PR on other repos.

### Other Information

See: https://github.com/expressjs/multer/issues/171 for more info