### PR TITLE
added support for nested password fields option in hash password hook

### DIFF
--- a/lib/hooks/hash-password.js
+++ b/lib/hooks/hash-password.js
@@ -39,9 +39,7 @@ module.exports = function hashPassword (options = {}) {
     return Promise.all(data.map(item => {
       const password = get(item, field);
       if (password) {
-        return hashPw(password).then(hashedPassword => {
-          return set(item, field, hashedPassword);
-        });
+        return hashPw(password).then(hashedPassword => set(item, field, hashedPassword));
       }
 
       return item;

--- a/lib/hooks/hash-password.js
+++ b/lib/hooks/hash-password.js
@@ -1,5 +1,5 @@
 const hasher = require('../utils/hash');
-const { merge } = require('lodash');
+const { merge, get, set } = require('lodash');
 const Debug = require('debug');
 
 const debug = Debug('@feathersjs/authentication-local:hooks:hash-password');
@@ -37,11 +37,10 @@ module.exports = function hashPassword (options = {}) {
     const data = dataIsArray ? context.data : [ context.data ];
 
     return Promise.all(data.map(item => {
-      if (Object.prototype.hasOwnProperty.call(item, field)) {
-        return hashPw(item[field]).then(hashedPassword => {
-          return Object.assign(item, {
-            [field]: hashedPassword
-          });
+      const password = get(item, field);
+      if (password) {
+        return hashPw(password).then(hashedPassword => {
+          return set(item, field, hashedPassword);
         });
       }
 

--- a/test/hooks/hash-password.test.js
+++ b/test/hooks/hash-password.test.js
@@ -81,6 +81,19 @@ describe('hooks:hashPassword', () => {
       });
     });
 
+    it('hashes with nested password field custom option', () => {
+      hook.data = {
+        nested: {
+          pass: 'secret'
+        }
+      };
+
+      return hashPassword({ passwordField: 'nested.pass' })(hook).then(hook => {
+        expect(hook.data.nested.pass).to.not.equal(undefined);
+        expect(hook.data.nested.pass).to.not.equal('secret');
+      });
+    });
+
     it('calls custom hash function', () => {
       const fn = sinon.stub().returns(Promise.resolve());
       return hashPassword({ hash: fn })(hook).then(() => {


### PR DESCRIPTION
### Summary


Hash password hook does not currently support nested fields e.g. `field: 'nested.password'`

No open issues currently.

Added lodash get and set to check and set the nested property, also added a test case.


